### PR TITLE
C++ 20 Fix | UE5.3

### DIFF
--- a/Source/TCPClientPlugin/Private/TCPClient.cpp
+++ b/Source/TCPClientPlugin/Private/TCPClient.cpp
@@ -89,7 +89,7 @@ int32 TCPClient::BeginConnect(const FIPv4Endpoint endpoint, std::function<void(F
     RemoteAddress->SetIp(endpoint.Address.Value);
     RemoteAddress->SetPort(endpoint.Port);
 
-    ThrdPool->EnqueueJob([=, this]()
+    ThrdPool->EnqueueJob([this, RemoteAddress, state, connectCallback]()
         {
             if (Socket == nullptr) return;
             bool connected = Socket->Connect(*RemoteAddress);
@@ -122,7 +122,7 @@ int32 TCPClient::BeginSend(FByteArrayRef& sendBuffPtr, std::function<void(FAsync
         return 0;
     }
 
-    ThrdPool->EnqueueJob([=, this]()
+    ThrdPool->EnqueueJob([this, RemoteAddress, state, connectCallback]()
         {
             while (!SendingQueue.IsEmpty() && bConnected)
             {
@@ -174,7 +174,7 @@ int32 TCPClient::BeginRecv(uint8* buffer, int32 bufferSize, std::function<void(F
     }
 #pragma endregion
 
-    ThrdPool->EnqueueJob([=, this]()
+    ThrdPool->EnqueueJob([this, RemoteAddress, state, connectCallback]()
         {
             int32 byteRead = 0;
             if (Socket == nullptr) return;

--- a/Source/TCPClientPlugin/Private/TCPClient.cpp
+++ b/Source/TCPClientPlugin/Private/TCPClient.cpp
@@ -89,7 +89,7 @@ int32 TCPClient::BeginConnect(const FIPv4Endpoint endpoint, std::function<void(F
     RemoteAddress->SetIp(endpoint.Address.Value);
     RemoteAddress->SetPort(endpoint.Port);
 
-    ThrdPool->EnqueueJob([=]()
+    ThrdPool->EnqueueJob([=, this]()
         {
             if (Socket == nullptr) return;
             bool connected = Socket->Connect(*RemoteAddress);
@@ -122,7 +122,7 @@ int32 TCPClient::BeginSend(FByteArrayRef& sendBuffPtr, std::function<void(FAsync
         return 0;
     }
 
-    ThrdPool->EnqueueJob([=]()
+    ThrdPool->EnqueueJob([=, this]()
         {
             while (!SendingQueue.IsEmpty() && bConnected)
             {
@@ -174,7 +174,7 @@ int32 TCPClient::BeginRecv(uint8* buffer, int32 bufferSize, std::function<void(F
     }
 #pragma endregion
 
-    ThrdPool->EnqueueJob([=]()
+    ThrdPool->EnqueueJob([=, this]()
         {
             int32 byteRead = 0;
             if (Socket == nullptr) return;


### PR DESCRIPTION
There's an error for /std:c++20

[Error]C4855 implicit capture of 'this' via '[=]' is deprecated in '/std:c++20'

Fixing the plugin to
 ThrdPool->EnqueueJob([=, this]()